### PR TITLE
Update path of boostrap to working path using latest adminlte

### DIFF
--- a/src/app/BackProjectServiceProvider.php
+++ b/src/app/BackProjectServiceProvider.php
@@ -115,7 +115,7 @@ class BackProjectServiceProvider extends ServiceProvider
         // publish error views
         $this->publishes([__DIR__ . '/../resources/error_views' => resource_path('views/errors')], 'errors');
         // publish public AdminLTE assets
-        $this->publishes(['vendor/almasaeed2010/adminlte/bootstrap' => public_path('vendor/adminlte/bootstrap')], 'adminlte');
+        $this->publishes(['vendor/almasaeed2010/adminlte/bower_components/bootstrap/dist' => public_path('vendor/adminlte/bootstrap')], 'adminlte');
         $this->publishes(['vendor/almasaeed2010/adminlte/dist' => public_path('vendor/adminlte/dist')], 'adminlte');
         $this->publishes(['vendor/almasaeed2010/adminlte/plugins' => public_path('vendor/adminlte/plugins')], 'adminlte');
     }


### PR DESCRIPTION
Had an error where `boostrap.min.js` wasn't being loaded.  This change fixes that.  It's needed as the `adminlte` package changed the location of `boostrap.min.js`