### PR TITLE
Remove form-horizontal to make login form better

### DIFF
--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -14,7 +14,7 @@ login-page
         <div class="login-box-body">
             <p class="login-box-msg">{{ trans('back-project::base.login_message') }}</p>
 
-            <form class="form-horizontal" role="form" method="POST" action="{{ url('login') }}">
+            <form role="form" method="POST" action="{{ url('login') }}">
                 {{ csrf_field() }}
 
                 <div class="form-group has-feedback{{ $errors->has('email') ? ' has-error' : '' }}">

--- a/src/resources/views/auth/passwords/email.blade.php
+++ b/src/resources/views/auth/passwords/email.blade.php
@@ -14,7 +14,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">{{ trans('back-project::base.forgot_password_message') }}</p>
 
-        <form class="form-horizontal" role="form" method="POST" action="{{ url('password/email') }}">
+        <form role="form" method="POST" action="{{ url('password/email') }}">
             {{ csrf_field() }}
 
             <div class="form-group has-feedback{{ $errors->has('email') ? ' has-error' : '' }}">

--- a/src/resources/views/auth/passwords/reset.blade.php
+++ b/src/resources/views/auth/passwords/reset.blade.php
@@ -14,7 +14,7 @@
     <div class="register-box-body">
       <p class="register-box-msg">{{ trans('back-project::base.reset_password') }}</p>
 
-      <form class="form-horizontal" role="form" method="POST" action="{{ url('/password/reset') }}">
+      <form role="form" method="POST" action="{{ url('/password/reset') }}">
         {!! csrf_field() !!}
 
         <input type="hidden" name="token" value="{{ $token }}">

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -13,7 +13,7 @@
     <div class="register-box-body">
       <p class="login-box-msg">{{ trans('back-project::base.register') }}</p>
 
-      <form class="form-horizontal" role="form" method="POST" action="{{ url('register') }}">
+      <form role="form" method="POST" action="{{ url('register') }}">
           {{ csrf_field() }}
 
           <div class="form-group has-feedback{{ $errors->has('username') ? ' has-error' : '' }}">


### PR DESCRIPTION
Login forms extend widthwise too much when `class="form-horizontal"` is enable in the latest `adminlte`:
![screenshot-2017-10-18 http localhost](https://user-images.githubusercontent.com/1734126/31702548-4215f95c-b40a-11e7-860e-7aca26f90a31.png)
Removing it makes it look better:
![screenshot-2017-10-18 http localhost 1](https://user-images.githubusercontent.com/1734126/31702558-4b65fdd6-b40a-11e7-8b56-4a8e9bb84de6.png)
