### PR TITLE
Prevent logout -> back still viewable problem

### DIFF
--- a/src/resources/views/layouts/admin.blade.php
+++ b/src/resources/views/layouts/admin.blade.php
@@ -1,3 +1,9 @@
+<?php
+  //set headers to NOT cache a page
+  header("Cache-Control: no-store, no-cache, must-revalidate"); //HTTP 1.1
+  header("Pragma: no-cache"); //HTTP 1.0
+  header("Expires: Thu, 19 Nov 1981 08:52:00 GMT"); // Date in the past
+?>
 {{-- Admin layout - author <afrittella> --}}<!DOCTYPE html>
 <html lang="en">
 


### PR DESCRIPTION
When I logout and click the back button in the browser, I am still able to view the logged in page.  Of course, I am not able to modify anything but it's the logged in session is still viewable when it can be prevented. 

Adding this headers, and more specifically `Cache-Control: no-store` fixes the problem.