### PR TITLE
Redirect to login when $app_user is not an object

### DIFF
--- a/src/app/Http/ViewComposers/AdminMenuComposer.php
+++ b/src/app/Http/ViewComposers/AdminMenuComposer.php
@@ -74,7 +74,7 @@ class AdminMenuComposer
             $menuString = "";
             $hasActive = false;
             foreach ($rows as $menu) {
-                if (!empty($menu->permission) and !$user->hasPermission($menu->permission)) {
+                if (!empty($menu->permission) and $user and !$user->hasPermission($menu->permission)) {
                     continue;
                 }
 

--- a/src/resources/views/inc/nav.blade.php
+++ b/src/resources/views/inc/nav.blade.php
@@ -1,11 +1,3 @@
-<?php
-if (!is_object($app_user))
-{
-    $app_user = new stdclass();
-    $app_user->username = 'Anonymous';
-    $app_user->email = null;
-}
-?>
 <div class="navbar-custom-menu">
     <ul class="nav navbar-nav">
         <li class="dropdown notifications-menu user user-menu">

--- a/src/resources/views/inc/nav.blade.php
+++ b/src/resources/views/inc/nav.blade.php
@@ -1,3 +1,11 @@
+<?php
+if (!is_object($app_user))
+{
+    $app_user = new stdclass();
+    $app_user->username = 'Anonymous';
+    $app_user->email = null;
+}
+?>
 <div class="navbar-custom-menu">
     <ul class="nav navbar-nav">
         <li class="dropdown notifications-menu user user-menu">
@@ -48,4 +56,3 @@
         </li>
     </ul>
 </div>
-

--- a/src/resources/views/layouts/admin.blade.php
+++ b/src/resources/views/layouts/admin.blade.php
@@ -1,3 +1,7 @@
+<?php
+if (isset($app_user) && !is_object($app_user))
+    header('Location: '.route('login'));
+?>
 {{-- Admin layout - author <afrittella> --}}<!DOCTYPE html>
 <html lang="en">
 


### PR DESCRIPTION
I had an instance where the page displayed an error because $app_user was not an object.  I think it was because of an expired session.  This will make sure that the user will be redirected to a login if $app_user is not an object.